### PR TITLE
Additional ctor with X509Certificate2

### DIFF
--- a/CavemanTcp/CavemanTcp.csproj
+++ b/CavemanTcp/CavemanTcp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;netstandard2.0;net461;net5.0;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.9</Version>
+    <Version>1.3.10</Version>
     <Authors>Joel Christner</Authors>
     <Description>CavemanTcp is a simple TCP client and server providing easy integration and full control over network reads and writes, allowing you to build your own state machines with ease.</Description>
     <Copyright>(c)2021 Joel Christner</Copyright>

--- a/CavemanTcp/CavemanTcp.xml
+++ b/CavemanTcp/CavemanTcp.xml
@@ -398,6 +398,14 @@
             <param name="pfxCertFilename">The filename of the PFX certificate file.</param>
             <param name="pfxPassword">The password to the PFX certificate file.</param>
         </member>
+        <member name="M:CavemanTcp.CavemanTcpServer.#ctor(System.String,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate2)">
+            <summary>
+            Instantiates the TCP server.  Set the ClientConnected, ClientDisconnected, and DataReceived callbacks.  Once set, use Start() to begin listening for connections.
+            </summary>
+            <param name="listenerIp">The listener IP address or hostname.</param>
+            <param name="port">The TCP port on which to listen.</param>
+            <param name="sslCertificate">The certificate for SSL listen.</param>
+        </member>
         <member name="M:CavemanTcp.CavemanTcpServer.Dispose">
             <summary>
             Dispose of the TCP server.

--- a/CavemanTcp/CavemanTcpServer.cs
+++ b/CavemanTcp/CavemanTcpServer.cs
@@ -328,6 +328,19 @@ namespace CavemanTcp
             _Header = "[CavemanTcp.Server " + _ListenerIp + ":" + _Port + "] ";
         }
 
+        /// <summary>
+        /// Instantiates the TCP server.  Set the ClientConnected, ClientDisconnected, and DataReceived callbacks.  Once set, use Start() to begin listening for connections.
+        /// </summary>
+        /// <param name="listenerIp">The listener IP address or hostname.</param>
+        /// <param name="port">The TCP port on which to listen.</param>
+        /// <param name="sslCertificate">The certificate for SSL listen.</param>
+        public CavemanTcpServer(string listenerIp, int port, X509Certificate2 sslCertificate) : this(listenerIp, port)
+        {
+            _Ssl = true;
+            _SslCertificate = sslCertificate ?? throw new ArgumentException("Certificate must be not null.");
+            _SslCertificateCollection = new X509Certificate2Collection { _SslCertificate };
+        }
+
         #endregion
 
         #region Public-Methods


### PR DESCRIPTION
Sometimes the certificate is only available in store or vault, not on disk as pfx file.
Adding a ctor for those cases (my particular interest).
