### PR TITLE
Added an optional message terminator option for read methods.

### DIFF
--- a/src/CavemanTcp/CavemanTcp.xml
+++ b/src/CavemanTcp/CavemanTcp.xml
@@ -1,1137 +1,1137 @@
 <?xml version="1.0"?>
 <doc>
-    <assembly>
-        <name>CavemanTcp</name>
-    </assembly>
-    <members>
-        <member name="T:CavemanTcp.CavemanTcpClient">
-            <summary>
-            CavemanTcp is a simple TCP client and server providing callers with easy integration and full control over network reads and writes.
-            Once instantiated, use Connect(int) to connect to the server.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpClient.IsConnected">
-            <summary>
-            Indicates if the client is connected to the server.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.CavemanTcpClient.Logger">
-            <summary>
-            Method to invoke when sending log messages.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpClient.Settings">
-            <summary>
-            CavemanTcp client settings.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpClient.Events">
-            <summary>
-            CavemanTcp client events.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpClient.Statistics">
-            <summary>
-            CavemanTcp statistics.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpClient.Keepalive">
-            <summary>
-            CavemanTcp keepalive settings.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.#ctor(System.String)">
-            <summary>
-            Instantiates the TCP client without SSL.  Set the Connected, Disconnected, and DataReceived callbacks.  Once set, use Connect() to connect to the server.
-            </summary>
-            <param name="ipPort">The IP:port of the server.</param> 
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.#ctor(System.String,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate2)">
-            <summary>
-            Instantiates the TCP client without SSL.  Set the Connected, Disconnected, and DataReceived callbacks.  Once set, use Connect() to connect to the server.
-            </summary>
-            <param name="serverIpOrHostname">The server IP address or hostname.</param>
-            <param name="port">The TCP port on which to connect.</param>
-            <param name="certificate">SSL certificate.</param>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.#ctor(System.String,System.Boolean,System.String,System.String)">
-            <summary>
-            Instantiates the TCP client.  Set the Connected, Disconnected, and DataReceived callbacks.  Once set, use Connect() to connect to the server.
-            </summary>
-            <param name="ipPort">The IP:port of the server.</param> 
-            <param name="ssl">Enable or disable SSL.</param>
-            <param name="pfxCertFilename">The filename of the PFX certificate file.</param>
-            <param name="pfxPassword">The password to the PFX certificate file.</param>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.#ctor(System.String,System.Int32,System.Boolean,System.String,System.String)">
-            <summary>
-            Instantiates the TCP client.  Set the Connected, Disconnected, and DataReceived callbacks.  Once set, use Connect() to connect to the server.
-            </summary>
-            <param name="serverIpOrHostname">The server IP address or hostname.</param>
-            <param name="port">The TCP port on which to connect.</param>
-            <param name="ssl">Enable or disable SSL.</param>
-            <param name="pfxCertFilename">The filename of the PFX certificate file.</param>
-            <param name="pfxPassword">The password to the PFX certificate file.</param>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.Dispose">
-            <summary>
-            Dispose of the TCP client.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.Connect(System.Int32)">
-            <summary>
-            Establish the connection to the server.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.Disconnect">
-            <summary>
-            Disconnect from the server.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.Send(System.String)">
-            <summary>
-            Send data to the server.
-            </summary>
-            <param name="data">String data.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.Send(System.Byte[])">
-            <summary>
-            Send data to the server.
-            </summary> 
-            <param name="data">Byte array containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.Send(System.Int64,System.IO.Stream)">
-            <summary>
-            Send data to the server.
-            </summary> 
-            <param name="contentLength">Number of bytes to send from the stream.</param>
-            <param name="stream">Stream containing data.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.SendWithTimeout(System.Int32,System.String)">
-            <summary>
-            Send data to the server.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="data">String data.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.SendWithTimeout(System.Int32,System.Byte[])">
-            <summary>
-            Send data to the server.
-            </summary> 
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="data">Byte array containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.SendWithTimeout(System.Int32,System.Int64,System.IO.Stream)">
-            <summary>
-            Send data to the server.
-            </summary> 
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="contentLength">Number of bytes to send from the stream.</param>
-            <param name="stream">Stream containing data.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.SendAsync(System.String,System.Threading.CancellationToken)">
-            <summary>
-            Send data to the server.
-            </summary>
-            <param name="data">String data.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.SendAsync(System.Byte[],System.Threading.CancellationToken)">
-            <summary>
-            Send data to the server.
-            </summary> 
-            <param name="data">Byte array containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.SendAsync(System.Int64,System.IO.Stream,System.Threading.CancellationToken)">
-            <summary>
-            Send data to the server.
-            </summary> 
-            <param name="contentLength">Number of bytes to send from the stream.</param>
-            <param name="stream">Stream containing data.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.SendWithTimeoutAsync(System.Int32,System.String,System.Threading.CancellationToken)">
-            <summary>
-            Send data to the server.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="data">String data.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.SendWithTimeoutAsync(System.Int32,System.Byte[],System.Threading.CancellationToken)">
-            <summary>
-            Send data to the server.
-            </summary> 
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="data">Byte array containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.SendWithTimeoutAsync(System.Int32,System.Int64,System.IO.Stream,System.Threading.CancellationToken)">
-            <summary>
-            Send data to the server.
-            </summary> 
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="contentLength">Number of bytes to send from the stream.</param>
-            <param name="stream">Stream containing data.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.Read(System.Int32)">
-            <summary>
-            Read from the server.
-            </summary>
-            <param name="count">The number of bytes to read.</param>
-            <returns>ReadResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.ReadWithTimeout(System.Int32,System.Int32)">
-            <summary>
-            Read from the server.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="count">The number of bytes to read.</param>
-            <returns>ReadResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.ReadAsync(System.Int32,System.Threading.CancellationToken)">
-            <summary>
-            Read from the server.
-            </summary>
-            <param name="count">The number of bytes to read.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>ReadResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.ReadWithTimeoutAsync(System.Int32,System.Int32,System.Threading.CancellationToken)">
-            <summary>
-            Read from the server.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="count">The number of bytes to read.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>ReadResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.GetStream">
-            <summary>
-            Get direct access to the underlying client stream.
-            </summary>
-            <returns>Stream.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.Dispose(System.Boolean)">
-            <summary>
-            Dispose of the TCP client.
-            </summary>
-            <param name="disposing">Dispose of resources.</param>
-        </member>
-        <member name="T:CavemanTcp.CavemanTcpClientEvents">
-            <summary>
-            CavemanTcp client events.
-            </summary>
-        </member>
-        <member name="E:CavemanTcp.CavemanTcpClientEvents.ClientConnected">
-            <summary>
-            Event to fire when the client connects.
-            </summary>
-        </member>
-        <member name="E:CavemanTcp.CavemanTcpClientEvents.ClientDisconnected">
-            <summary>
-            Event to fire when the client disconnects.
-            </summary>
-        </member>
-        <member name="E:CavemanTcp.CavemanTcpClientEvents.ExceptionEncountered">
-            <summary>
-            Event to fire when an exception is encountered.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClientEvents.#ctor">
-            <summary>
-            Instantiate the object.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.CavemanTcpClientSettings">
-            <summary>
-            CavemanTcp client settings.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpClientSettings.StreamBufferSize">
-            <summary>
-            Buffer size to use while interacting with streams.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpClientSettings.AcceptInvalidCertificates">
-            <summary>
-            Enable or disable acceptance of invalid SSL certificates.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpClientSettings.MutuallyAuthenticate">
-            <summary>
-            Enable or disable mutual authentication of SSL client and server.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpClientSettings.EnableConnectionMonitor">
-            <summary>
-            Enable or disable connection monitor.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpClientSettings.PollIntervalMicroSeconds">
-            <summary>
-            Connection monitor polling interval, in microseconds.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClientSettings.#ctor">
-            <summary>
-            Instantiate the object.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.CavemanTcpKeepaliveSettings">
-            <summary>
-            CavemanTcp keepalive settings.
-            Keepalive probes are sent after an idle period defined by TcpKeepAliveTime (seconds).
-            Should a keepalive response not be received within TcpKeepAliveInterval (seconds), a subsequent keepalive probe will be sent.
-            For .NET Framework, should 10 keepalive probes fail, the connection will terminate.
-            For .NET Core, should a number of probes fail as specified in TcpKeepAliveRetryCount, the connection will terminate.
-            TCP keepalives are not supported in .NET Standard.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.CavemanTcpKeepaliveSettings.EnableTcpKeepAlives">
-            <summary>
-            Enable or disable TCP-based keepalive probes.
-            TCP keepalives are only supported in .NET Core and .NET Framework projects.  .NET Standard does not provide facilities to support TCP keepalives.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpKeepaliveSettings.TcpKeepAliveInterval">
-            <summary>
-            TCP keepalive interval, i.e. the number of seconds a TCP connection will wait for a keepalive response before sending another keepalive probe.
-            Default is 5 seconds.  Value must be greater than zero.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpKeepaliveSettings.TcpKeepAliveTime">
-            <summary>
-            TCP keepalive time, i.e. the number of seconds a TCP connection will remain alive/idle before keepalive probes are sent to the remote. 
-            Default is 5 seconds.  Value must be greater than zero.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpKeepaliveSettings.TcpKeepAliveRetryCount">
-            <summary>
-            TCP keepalive retry count, i.e. the number of times a TCP probe will be sent in effort to verify the connection.
-            After the specified number of probes fail, the connection will be terminated.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpKeepaliveSettings.#ctor">
-            <summary>
-            Instantiate the object.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.CavemanTcpServer">
-            <summary>
-            CavemanTcp is a simple TCP client and server providing callers with easy integration and full control over network reads and writes.
-            Set the ClientConnected and ClientDisconnected callbacks, then, use Start() to begin listening for connections.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpServer.IsListening">
-            <summary>
-            Indicates if the server is listening for connections.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.CavemanTcpServer.Logger">
-            <summary>
-            Method to invoke when sending log messages.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpServer.Settings">
-            <summary>
-            CavemanTcp server settings.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpServer.Events">
-            <summary>
-            CavemanTcp server callbacks.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpServer.Statistics">
-            <summary>
-            CavemanTcp statistics.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpServer.Keepalive">
-            <summary>
-            CavemanTcp keepalive settings.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.#ctor(System.String)">
-            <summary>
-            Instantiates the TCP server without SSL.  Set the ClientConnected, ClientDisconnected, and DataReceived callbacks.  Once set, use Start() to begin listening for connections.
-            </summary>
-            <param name="ipPort">The IP:port of the server.</param> 
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.#ctor(System.String,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate2)">
-            <summary>
-            Instantiates the TCP server without SSL.  Set the ClientConnected, ClientDisconnected, and DataReceived callbacks.  Once set, use Start() to begin listening for connections.
-            </summary>
-            <param name="listenerIp">The listener IP address or hostname.</param>
-            <param name="port">The TCP port on which to listen.</param> 
-            <param name="certificate">SSL certificate.</param>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.#ctor(System.String,System.Boolean,System.String,System.String)">
-            <summary>
-            Instantiates the TCP server.  Set the ClientConnected, ClientDisconnected, and DataReceived callbacks.  Once set, use Start() to begin listening for connections.
-            </summary>
-            <param name="ipPort">The IP:port of the server.</param> 
-            <param name="ssl">Enable or disable SSL.</param>
-            <param name="pfxCertFilename">The filename of the PFX certificate file.</param>
-            <param name="pfxPassword">The password to the PFX certificate file.</param>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.#ctor(System.String,System.Int32,System.Boolean,System.String,System.String)">
-            <summary>
-            Instantiates the TCP server.  Set the ClientConnected, ClientDisconnected, and DataReceived callbacks.  Once set, use Start() to begin listening for connections.
-            </summary>
-            <param name="listenerIp">The listener IP address or hostname.</param>
-            <param name="port">The TCP port on which to listen.</param>
-            <param name="ssl">Enable or disable SSL.</param>
-            <param name="pfxCertFilename">The filename of the PFX certificate file.</param>
-            <param name="pfxPassword">The password to the PFX certificate file.</param>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.Dispose">
-            <summary>
-            Dispose of the TCP server.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.Start">
-            <summary>
-            Start accepting connections.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.StartAsync(System.Threading.CancellationToken)">
-            <summary>
-            Start accepting connections.
-            </summary>
-            <param name="token">Cancellation token for canceling the server.</param>
-            <returns>Task.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.Stop">
-            <summary>
-            Stop accepting new connections.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.GetClients">
-            <summary>
-            Retrieve a list of client metadata for clients connected to the server.
-            </summary>
-            <returns>IEnumerable of ClientMetadata.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.Send(System.String,System.String)">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="data">String containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.Send(System.Guid,System.String)">
-            <summary>
-            Send data to the specified client by GUID.
-            </summary>
-            <param name="guid">Client GUID.</param>
-            <param name="data">String containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.Send(System.String,System.Byte[])">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="data">Byte array containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.Send(System.Guid,System.Byte[])">
-            <summary>
-            Send data to the specified client by GUID.
-            </summary>
-            <param name="guid">Client GUID.</param>
-            <param name="data">Byte array containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.Send(System.String,System.Int64,System.IO.Stream)">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="contentLength">Number of bytes to send from the stream.</param>
-            <param name="stream">Stream containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.Send(System.Guid,System.Int64,System.IO.Stream)">
-            <summary>
-            Send data to the specified client by GUID.
-            </summary>
-            <param name="guid">Client GUID.</param>
-            <param name="contentLength">Number of bytes to send from the stream.</param>
-            <param name="stream">Stream containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeout(System.Int32,System.String,System.String)">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="data">String containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeout(System.Int32,System.Guid,System.String)">
-            <summary>
-            Send data to the specified client by GUID.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="guid">Client GUID.</param>
-            <param name="data">String containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeout(System.Int32,System.String,System.Byte[])">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="data">Byte array containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeout(System.Int32,System.Guid,System.Byte[])">
-            <summary>
-            Send data to the specified client by GUID.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="guid">Client GUID.</param>
-            <param name="data">Byte array containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeout(System.Int32,System.String,System.Int64,System.IO.Stream)">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="contentLength">Number of bytes to send from the stream.</param>
-            <param name="stream">Stream containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeout(System.Int32,System.Guid,System.Int64,System.IO.Stream)">
-            <summary>
-            Send data to the specified client by GUID.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="guid">Client GUID.</param>
-            <param name="contentLength">Number of bytes to send from the stream.</param>
-            <param name="stream">Stream containing data to send.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendAsync(System.String,System.String,System.Threading.CancellationToken)">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="data">String containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendAsync(System.Guid,System.String,System.Threading.CancellationToken)">
-            <summary>
-            Send data to the specified client by GUID.
-            </summary>
-            <param name="guid">Client GUID.</param>
-            <param name="data">String containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendAsync(System.String,System.Byte[],System.Threading.CancellationToken)">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="data">Byte array containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendAsync(System.Guid,System.Byte[],System.Threading.CancellationToken)">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="guid">Client GUID.</param>
-            <param name="data">Byte array containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendAsync(System.String,System.Int64,System.IO.Stream,System.Threading.CancellationToken)">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="contentLength">Number of bytes to send from the stream.</param>
-            <param name="stream">Stream containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendAsync(System.Guid,System.Int64,System.IO.Stream,System.Threading.CancellationToken)">
-            <summary>
-            Send data to the specified client by GUID.
-            </summary>
-            <param name="guid">Client GUID.</param>
-            <param name="contentLength">Number of bytes to send from the stream.</param>
-            <param name="stream">Stream containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeoutAsync(System.Int32,System.String,System.String,System.Threading.CancellationToken)">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="data">String containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeoutAsync(System.Int32,System.Guid,System.String,System.Threading.CancellationToken)">
-            <summary>
-            Send data to the specified client by GUID.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="guid">Client GUID.</param>
-            <param name="data">String containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeoutAsync(System.Int32,System.String,System.Byte[],System.Threading.CancellationToken)">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="data">Byte array containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeoutAsync(System.Int32,System.Guid,System.Byte[],System.Threading.CancellationToken)">
-            <summary>
-            Send data to the specified client by GUID.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="guid">Client GUID.</param>
-            <param name="data">Byte array containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeoutAsync(System.Int32,System.String,System.Int64,System.IO.Stream,System.Threading.CancellationToken)">
-            <summary>
-            Send data to the specified client by IP:port.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="contentLength">Number of bytes to send from the stream.</param>
-            <param name="stream">Stream containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeoutAsync(System.Int32,System.Guid,System.Int64,System.IO.Stream,System.Threading.CancellationToken)">
-            <summary>
-            Send data to the specified client by GUID.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="guid">Client GUID.</param>
-            <param name="contentLength">Number of bytes to send from the stream.</param>
-            <param name="stream">Stream containing data to send.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>WriteResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.DisconnectClient(System.String)">
-            <summary>
-            Disconnects the specified client.
-            </summary>
-            <param name="ipPort">IP:port of the client.</param>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.DisconnectClient(System.Guid)">
-            <summary>
-            Disconnects the specified client.
-            </summary>
-            <param name="guid">Client GUID.</param>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.Read(System.String,System.Int32)">
-            <summary>
-            Read data from a given client.
-            </summary>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="count">The number of bytes to read.</param>
-            <returns>ReadResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.Read(System.Guid,System.Int32)">
-            <summary>
-            Read data from a given client.
-            </summary>
-            <param name="guid">Client GUID.</param>
-            <param name="count">The number of bytes to read.</param>
-            <returns>ReadResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.ReadWithTimeout(System.Int32,System.String,System.Int32)">
-            <summary>
-            Read data from a given client.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="count">The number of bytes to read.</param>
-            <returns>ReadResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.ReadWithTimeout(System.Int32,System.Guid,System.Int32)">
-            <summary>
-            Read data from a given client.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="guid">Client GUID.</param>
-            <param name="count">The number of bytes to read.</param>
-            <returns>ReadResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.ReadAsync(System.String,System.Int32,System.Threading.CancellationToken)">
-            <summary>
-            Read data from a given client.
-            </summary>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="count">The number of bytes to read.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>ReadResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.ReadAsync(System.Guid,System.Int32,System.Threading.CancellationToken)">
-            <summary>
-            Read data from a given client.
-            </summary>
-            <param name="guid">Client GUID.</param>
-            <param name="count">The number of bytes to read.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>ReadResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.ReadWithTimeoutAsync(System.Int32,System.String,System.Int32,System.Threading.CancellationToken)">
-            <summary>
-            Read data from a given client.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="ipPort">The client IP:port.</param>
-            <param name="count">The number of bytes to read.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>ReadResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.ReadWithTimeoutAsync(System.Int32,System.Guid,System.Int32,System.Threading.CancellationToken)">
-            <summary>
-            Read data from a given client.
-            </summary>
-            <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
-            <param name="guid">Client GUID.</param>
-            <param name="count">The number of bytes to read.</param>
-            <param name="token">Cancellation token for canceling the request.</param>
-            <returns>ReadResult.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.GetStream(System.String)">
-            <summary>
-            Get direct access to the underlying client stream.
-            </summary>
-            <param name="ipPort">The client IP:port.</param>
-            <returns>Stream.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.GetStream(System.Guid)">
-            <summary>
-            Get direct access to the underlying client stream.
-            </summary>
-            <param name="guid">Client GUID.</param>
-            <returns>Stream.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.IsConnected(System.String)">
-            <summary>
-            Determines if a client is connected by its IP:port.
-            </summary>
-            <param name="ipPort">The client IP:port.</param>
-            <returns>True if connected.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.IsConnected(System.Guid)">
-            <summary>
-            Determines if a client is connected by its GUID.
-            </summary>
-            <param name="guid">The client GUID.</param>
-            <returns>True if connected.</returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServer.Dispose(System.Boolean)">
-            <summary>
-            Dispose of the TCP server.
-            </summary>
-            <param name="disposing">Dispose of resources.</param>
-        </member>
-        <member name="T:CavemanTcp.CavemanTcpServerCallbacks">
-            <summary>
-            CavemanTcp server callbacks.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.CavemanTcpServerCallbacks.AuthorizeConnection">
-            <summary>
-            Callback to invoke when a connection is received to permit or deny the connection.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServerCallbacks.#ctor">
-            <summary>
-            Instantiate the object.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.CavemanTcpServerEvents">
-            <summary>
-            CavemanTcp server events.
-            </summary>
-        </member>
-        <member name="E:CavemanTcp.CavemanTcpServerEvents.ClientConnected">
-            <summary>
-            Event to fire when a client connects.  A string containing the client IP:port will be passed.
-            </summary>
-        </member>
-        <member name="E:CavemanTcp.CavemanTcpServerEvents.ClientDisconnected">
-            <summary>
-            Event to fire when a client disconnects.  A string containing the client IP:port will be passed.
-            </summary>
-        </member>
-        <member name="E:CavemanTcp.CavemanTcpServerEvents.ExceptionEncountered">
-            <summary>
-            Event to fire when an exception is encountered.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServerEvents.#ctor">
-            <summary>
-            Instantiate the object.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.CavemanTcpServerSettings">
-            <summary>
-            CavemanTcp server settings.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpServerSettings.StreamBufferSize">
-            <summary>
-            Buffer size to use while interacting with streams.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.CavemanTcpServerSettings.MonitorClientConnections">
-            <summary>
-            Enable client connection monitoring, which checks connectivity every second.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.CavemanTcpServerSettings.AcceptInvalidCertificates">
-            <summary>
-            Enable or disable acceptance of invalid SSL certificates.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.CavemanTcpServerSettings.MutuallyAuthenticate">
-            <summary>
-            Enable or disable mutual authentication of SSL client and server.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpServerSettings.MaxConnections">
-            <summary>
-            Maximum number of connections the server will accept.
-            Default is 4096.  Value must be greater than zero.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpServerSettings.PermittedIPs">
-            <summary>
-            The list of permitted IP addresses from which connections can be received.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpServerSettings.BlockedIPs">
-            <summary>
-            The list of blocked IP addresses from which connections will be declined.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpServerSettings.#ctor">
-            <summary>
-            Instantiate the object.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.CavemanTcpStatistics">
-            <summary>
-            CavemanTcp statistics.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpStatistics.StartTime">
-            <summary>
-            The time at which the client or server was started.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpStatistics.UpTime">
-            <summary>
-            The amount of time which the client or server has been up.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpStatistics.ReceivedBytes">
-            <summary>
-            The number of bytes received.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.CavemanTcpStatistics.SentBytes">
-            <summary>
-            The number of bytes sent.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpStatistics.#ctor">
-            <summary>
-            Initialize the statistics object.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpStatistics.ToString">
-            <summary>
-            Return human-readable version of the object.
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpStatistics.Reset">
-            <summary>
-            Reset statistics other than StartTime and UpTime.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.ClientConnectedEventArgs">
-            <summary>
-            Arguments for client connection events.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.ClientConnectedEventArgs.Client">
-            <summary>
-            Client metadata.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.ClientDeclinedEventArgs">
-            <summary>
-            Arguments for situations where client connections are declined.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.ClientDeclinedEventArgs.IpPort">
-            <summary>
-            The IP address and port number of the disconnected client socket.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.ClientDeclinedEventArgs.Reason">
-            <summary>
-            The reason for the disconnection.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.ClientDisconnectedEventArgs">
-            <summary>
-            Arguments for client disconnection events.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.ClientDisconnectedEventArgs.Client">
-            <summary>
-            Client metadata.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.ClientDisconnectedEventArgs.Reason">
-            <summary>
-            The reason for the disconnection.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.ClientMetadata">
-            <summary>
-            Client metadata.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.ClientMetadata.Guid">
-            <summary>
-            Globally-unique identifier for the connection.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.ClientMetadata.IpPort">
-            <summary>
-            IP:port.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.ClientMetadata.Name">
-            <summary>
-            Name for the client, managed by the developer (you).
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.ClientMetadata.Metadata">
-            <summary>
-            Metadata for the client, managed by the developer (you).
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.ClientMetadata.Dispose">
-            <summary>
-            Tear down the object and dispose of resources.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.ClientMetadata.ToString">
-            <summary>
-            Human-readable representation of the object.
-            </summary>
-            <returns></returns>
-        </member>
-        <member name="T:CavemanTcp.DisconnectReason">
-            <summary>
-            Reason why a client disconnected.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.DisconnectReason.Normal">
-            <summary>
-            Normal disconnection.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.DisconnectReason.Kicked">
-            <summary>
-            Client connection was intentionally terminated programmatically or by the server.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.DisconnectReason.Timeout">
-            <summary>
-            Client connection timed out; server did not receive data within the timeout window.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.DisconnectReason.ConnectionDeclined">
-            <summary>
-            The connection was declined.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.ExceptionEventArgs">
-            <summary>
-            Event arguments for when an exception is encountered. 
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.ExceptionEventArgs.Exception">
-            <summary>
-            Exception.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.ReadResult">
-            <summary>
-            Result of a read operation.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.ReadResult.Status">
-            <summary>
-            Status of the read operation.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.ReadResult.BytesRead">
-            <summary>
-            Number of bytes read.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.ReadResult.DataStream">
-            <summary>
-            Stream containing data.
-            </summary>
-        </member>
-        <member name="P:CavemanTcp.ReadResult.Data">
-            <summary>
-            Byte data from the stream.  Using this property will fully read the data stream and it will no longer be readable.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.ReadResult.#ctor">
-            <summary>
-            Instantiate the object.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.ReadResult.#ctor(CavemanTcp.ReadResultStatus,System.Int64,System.IO.MemoryStream)">
-            <summary>
-            Instantiate the object.
-            </summary>
-            <param name="status">Status of the read operation.</param>
-            <param name="bytesRead">Number of bytes read.</param>
-            <param name="data">Stream containing data.</param>
-        </member>
-        <member name="T:CavemanTcp.ReadResultStatus">
-            <summary>
-            Read result status.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.ReadResultStatus.ClientNotFound">
-            <summary>
-            The requested client was not found (only applicable for server read requests).
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.ReadResultStatus.Success">
-            <summary>
-            The read operation was successful.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.ReadResultStatus.Timeout">
-            <summary>
-            The operation timed out (reserved for future use).
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.ReadResultStatus.Disconnected">
-            <summary>
-            The connection was lost. 
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.ReadResultStatus.Canceled">
-            <summary>
-            The request was canceled.
-            </summary>
-        </member>
-        <member name="T:CavemanTcp.WriteResult">
-            <summary>
-            Result of a write operation.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.WriteResult.Status">
-            <summary>
-            Status of the write operation.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.WriteResult.BytesWritten">
-            <summary>
-            Number of bytes written.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.WriteResult.#ctor">
-            <summary>
-            Instantiate the object.
-            </summary>
-        </member>
-        <member name="M:CavemanTcp.WriteResult.#ctor(CavemanTcp.WriteResultStatus,System.Int64)">
-            <summary>
-            Instantiate the object.
-            </summary>
-            <param name="status">Status of the write operation.</param>
-            <param name="bytesWritten">Number of bytes written.</param>
-        </member>
-        <member name="T:CavemanTcp.WriteResultStatus">
-            <summary>
-            Write result status.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.WriteResultStatus.ClientNotFound">
-            <summary>
-            The requested client was not found (only applicable for server read requests).
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.WriteResultStatus.Success">
-            <summary>
-            The write operation was successful.
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.WriteResultStatus.Timeout">
-            <summary>
-            The operation timed out (reserved for future use).
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.WriteResultStatus.Disconnected">
-            <summary>
-            The connection was lost. 
-            </summary>
-        </member>
-        <member name="F:CavemanTcp.WriteResultStatus.Canceled">
-            <summary>
-            The request was canceled.
-            </summary>
-        </member>
-    </members>
+	<assembly>
+		<name>CavemanTcp</name>
+	</assembly>
+	<members>
+		<member name="T:CavemanTcp.CavemanTcpClient">
+			<summary>
+				CavemanTcp is a simple TCP client and server providing callers with easy integration and full control over network reads and writes.
+				Once instantiated, use Connect(int) to connect to the server.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpClient.IsConnected">
+			<summary>
+				Indicates if the client is connected to the server.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.CavemanTcpClient.Logger">
+			<summary>
+				Method to invoke when sending log messages.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpClient.Settings">
+			<summary>
+				CavemanTcp client settings.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpClient.Events">
+			<summary>
+				CavemanTcp client events.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpClient.Statistics">
+			<summary>
+				CavemanTcp statistics.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpClient.Keepalive">
+			<summary>
+				CavemanTcp keepalive settings.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.#ctor(System.String)">
+			<summary>
+				Instantiates the TCP client without SSL.  Set the Connected, Disconnected, and DataReceived callbacks.  Once set, use Connect() to connect to the server.
+			</summary>
+			<param name="ipPort">The IP:port of the server.</param>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.#ctor(System.String,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate2)">
+			<summary>
+				Instantiates the TCP client without SSL.  Set the Connected, Disconnected, and DataReceived callbacks.  Once set, use Connect() to connect to the server.
+			</summary>
+			<param name="serverIpOrHostname">The server IP address or hostname.</param>
+			<param name="port">The TCP port on which to connect.</param>
+			<param name="certificate">SSL certificate.</param>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.#ctor(System.String,System.Boolean,System.String,System.String)">
+			<summary>
+				Instantiates the TCP client.  Set the Connected, Disconnected, and DataReceived callbacks.  Once set, use Connect() to connect to the server.
+			</summary>
+			<param name="ipPort">The IP:port of the server.</param>
+			<param name="ssl">Enable or disable SSL.</param>
+			<param name="pfxCertFilename">The filename of the PFX certificate file.</param>
+			<param name="pfxPassword">The password to the PFX certificate file.</param>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.#ctor(System.String,System.Int32,System.Boolean,System.String,System.String)">
+			<summary>
+				Instantiates the TCP client.  Set the Connected, Disconnected, and DataReceived callbacks.  Once set, use Connect() to connect to the server.
+			</summary>
+			<param name="serverIpOrHostname">The server IP address or hostname.</param>
+			<param name="port">The TCP port on which to connect.</param>
+			<param name="ssl">Enable or disable SSL.</param>
+			<param name="pfxCertFilename">The filename of the PFX certificate file.</param>
+			<param name="pfxPassword">The password to the PFX certificate file.</param>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.Dispose">
+			<summary>
+				Dispose of the TCP client.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.Connect(System.Int32)">
+			<summary>
+				Establish the connection to the server.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.Disconnect">
+			<summary>
+				Disconnect from the server.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.Send(System.String)">
+			<summary>
+				Send data to the server.
+			</summary>
+			<param name="data">String data.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.Send(System.Byte[])">
+			<summary>
+				Send data to the server.
+			</summary>
+			<param name="data">Byte array containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.Send(System.Int64,System.IO.Stream)">
+			<summary>
+				Send data to the server.
+			</summary>
+			<param name="contentLength">Number of bytes to send from the stream.</param>
+			<param name="stream">Stream containing data.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.SendWithTimeout(System.Int32,System.String)">
+			<summary>
+				Send data to the server.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="data">String data.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.SendWithTimeout(System.Int32,System.Byte[])">
+			<summary>
+				Send data to the server.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="data">Byte array containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.SendWithTimeout(System.Int32,System.Int64,System.IO.Stream)">
+			<summary>
+				Send data to the server.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="contentLength">Number of bytes to send from the stream.</param>
+			<param name="stream">Stream containing data.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.SendAsync(System.String,System.Threading.CancellationToken)">
+			<summary>
+				Send data to the server.
+			</summary>
+			<param name="data">String data.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.SendAsync(System.Byte[],System.Threading.CancellationToken)">
+			<summary>
+				Send data to the server.
+			</summary>
+			<param name="data">Byte array containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.SendAsync(System.Int64,System.IO.Stream,System.Threading.CancellationToken)">
+			<summary>
+				Send data to the server.
+			</summary>
+			<param name="contentLength">Number of bytes to send from the stream.</param>
+			<param name="stream">Stream containing data.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.SendWithTimeoutAsync(System.Int32,System.String,System.Threading.CancellationToken)">
+			<summary>
+				Send data to the server.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="data">String data.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.SendWithTimeoutAsync(System.Int32,System.Byte[],System.Threading.CancellationToken)">
+			<summary>
+				Send data to the server.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="data">Byte array containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.SendWithTimeoutAsync(System.Int32,System.Int64,System.IO.Stream,System.Threading.CancellationToken)">
+			<summary>
+				Send data to the server.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="contentLength">Number of bytes to send from the stream.</param>
+			<param name="stream">Stream containing data.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.Read(System.Int32)">
+			<summary>
+				Read from the server.
+			</summary>
+			<param name="count">The number of bytes to read.</param>
+			<returns>ReadResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.ReadWithTimeout(System.Int32,System.Int32)">
+			<summary>
+				Read from the server.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="count">The number of bytes to read.</param>
+			<returns>ReadResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.ReadAsync(System.Int32,System.Threading.CancellationToken)">
+			<summary>
+				Read from the server.
+			</summary>
+			<param name="count">The number of bytes to read.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>ReadResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.ReadWithTimeoutAsync(System.Int32,System.Int32,System.Threading.CancellationToken)">
+			<summary>
+				Read from the server.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="count">The number of bytes to read.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>ReadResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.GetStream">
+			<summary>
+				Get direct access to the underlying client stream.
+			</summary>
+			<returns>Stream.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClient.Dispose(System.Boolean)">
+			<summary>
+				Dispose of the TCP client.
+			</summary>
+			<param name="disposing">Dispose of resources.</param>
+		</member>
+		<member name="T:CavemanTcp.CavemanTcpClientEvents">
+			<summary>
+				CavemanTcp client events.
+			</summary>
+		</member>
+		<member name="E:CavemanTcp.CavemanTcpClientEvents.ClientConnected">
+			<summary>
+				Event to fire when the client connects.
+			</summary>
+		</member>
+		<member name="E:CavemanTcp.CavemanTcpClientEvents.ClientDisconnected">
+			<summary>
+				Event to fire when the client disconnects.
+			</summary>
+		</member>
+		<member name="E:CavemanTcp.CavemanTcpClientEvents.ExceptionEncountered">
+			<summary>
+				Event to fire when an exception is encountered.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClientEvents.#ctor">
+			<summary>
+				Instantiate the object.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.CavemanTcpClientSettings">
+			<summary>
+				CavemanTcp client settings.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpClientSettings.StreamBufferSize">
+			<summary>
+				Buffer size to use while interacting with streams.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpClientSettings.AcceptInvalidCertificates">
+			<summary>
+				Enable or disable acceptance of invalid SSL certificates.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpClientSettings.MutuallyAuthenticate">
+			<summary>
+				Enable or disable mutual authentication of SSL client and server.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpClientSettings.EnableConnectionMonitor">
+			<summary>
+				Enable or disable connection monitor.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpClientSettings.PollIntervalMicroSeconds">
+			<summary>
+				Connection monitor polling interval, in microseconds.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpClientSettings.#ctor">
+			<summary>
+				Instantiate the object.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.CavemanTcpKeepaliveSettings">
+			<summary>
+				CavemanTcp keepalive settings.
+				Keepalive probes are sent after an idle period defined by TcpKeepAliveTime (seconds).
+				Should a keepalive response not be received within TcpKeepAliveInterval (seconds), a subsequent keepalive probe will be sent.
+				For .NET Framework, should 10 keepalive probes fail, the connection will terminate.
+				For .NET Core, should a number of probes fail as specified in TcpKeepAliveRetryCount, the connection will terminate.
+				TCP keepalives are not supported in .NET Standard.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.CavemanTcpKeepaliveSettings.EnableTcpKeepAlives">
+			<summary>
+				Enable or disable TCP-based keepalive probes.
+				TCP keepalives are only supported in .NET Core and .NET Framework projects.  .NET Standard does not provide facilities to support TCP keepalives.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpKeepaliveSettings.TcpKeepAliveInterval">
+			<summary>
+				TCP keepalive interval, i.e. the number of seconds a TCP connection will wait for a keepalive response before sending another keepalive probe.
+				Default is 5 seconds.  Value must be greater than zero.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpKeepaliveSettings.TcpKeepAliveTime">
+			<summary>
+				TCP keepalive time, i.e. the number of seconds a TCP connection will remain alive/idle before keepalive probes are sent to the remote.
+				Default is 5 seconds.  Value must be greater than zero.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpKeepaliveSettings.TcpKeepAliveRetryCount">
+			<summary>
+				TCP keepalive retry count, i.e. the number of times a TCP probe will be sent in effort to verify the connection.
+				After the specified number of probes fail, the connection will be terminated.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpKeepaliveSettings.#ctor">
+			<summary>
+				Instantiate the object.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.CavemanTcpServer">
+			<summary>
+				CavemanTcp is a simple TCP client and server providing callers with easy integration and full control over network reads and writes.
+				Set the ClientConnected and ClientDisconnected callbacks, then, use Start() to begin listening for connections.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpServer.IsListening">
+			<summary>
+				Indicates if the server is listening for connections.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.CavemanTcpServer.Logger">
+			<summary>
+				Method to invoke when sending log messages.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpServer.Settings">
+			<summary>
+				CavemanTcp server settings.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpServer.Events">
+			<summary>
+				CavemanTcp server callbacks.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpServer.Statistics">
+			<summary>
+				CavemanTcp statistics.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpServer.Keepalive">
+			<summary>
+				CavemanTcp keepalive settings.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.#ctor(System.String)">
+			<summary>
+				Instantiates the TCP server without SSL.  Set the ClientConnected, ClientDisconnected, and DataReceived callbacks.  Once set, use Start() to begin listening for connections.
+			</summary>
+			<param name="ipPort">The IP:port of the server.</param>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.#ctor(System.String,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate2)">
+			<summary>
+				Instantiates the TCP server without SSL.  Set the ClientConnected, ClientDisconnected, and DataReceived callbacks.  Once set, use Start() to begin listening for connections.
+			</summary>
+			<param name="listenerIp">The listener IP address or hostname.</param>
+			<param name="port">The TCP port on which to listen.</param>
+			<param name="certificate">SSL certificate.</param>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.#ctor(System.String,System.Boolean,System.String,System.String)">
+			<summary>
+				Instantiates the TCP server.  Set the ClientConnected, ClientDisconnected, and DataReceived callbacks.  Once set, use Start() to begin listening for connections.
+			</summary>
+			<param name="ipPort">The IP:port of the server.</param>
+			<param name="ssl">Enable or disable SSL.</param>
+			<param name="pfxCertFilename">The filename of the PFX certificate file.</param>
+			<param name="pfxPassword">The password to the PFX certificate file.</param>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.#ctor(System.String,System.Int32,System.Boolean,System.String,System.String)">
+			<summary>
+				Instantiates the TCP server.  Set the ClientConnected, ClientDisconnected, and DataReceived callbacks.  Once set, use Start() to begin listening for connections.
+			</summary>
+			<param name="listenerIp">The listener IP address or hostname.</param>
+			<param name="port">The TCP port on which to listen.</param>
+			<param name="ssl">Enable or disable SSL.</param>
+			<param name="pfxCertFilename">The filename of the PFX certificate file.</param>
+			<param name="pfxPassword">The password to the PFX certificate file.</param>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.Dispose">
+			<summary>
+				Dispose of the TCP server.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.Start">
+			<summary>
+				Start accepting connections.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.StartAsync(System.Threading.CancellationToken)">
+			<summary>
+				Start accepting connections.
+			</summary>
+			<param name="token">Cancellation token for canceling the server.</param>
+			<returns>Task.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.Stop">
+			<summary>
+				Stop accepting new connections.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.GetClients">
+			<summary>
+				Retrieve a list of client metadata for clients connected to the server.
+			</summary>
+			<returns>IEnumerable of ClientMetadata.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.Send(System.String,System.String)">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="data">String containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.Send(System.Guid,System.String)">
+			<summary>
+				Send data to the specified client by GUID.
+			</summary>
+			<param name="guid">Client GUID.</param>
+			<param name="data">String containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.Send(System.String,System.Byte[])">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="data">Byte array containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.Send(System.Guid,System.Byte[])">
+			<summary>
+				Send data to the specified client by GUID.
+			</summary>
+			<param name="guid">Client GUID.</param>
+			<param name="data">Byte array containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.Send(System.String,System.Int64,System.IO.Stream)">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="contentLength">Number of bytes to send from the stream.</param>
+			<param name="stream">Stream containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.Send(System.Guid,System.Int64,System.IO.Stream)">
+			<summary>
+				Send data to the specified client by GUID.
+			</summary>
+			<param name="guid">Client GUID.</param>
+			<param name="contentLength">Number of bytes to send from the stream.</param>
+			<param name="stream">Stream containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeout(System.Int32,System.String,System.String)">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="data">String containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeout(System.Int32,System.Guid,System.String)">
+			<summary>
+				Send data to the specified client by GUID.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="guid">Client GUID.</param>
+			<param name="data">String containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeout(System.Int32,System.String,System.Byte[])">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="data">Byte array containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeout(System.Int32,System.Guid,System.Byte[])">
+			<summary>
+				Send data to the specified client by GUID.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="guid">Client GUID.</param>
+			<param name="data">Byte array containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeout(System.Int32,System.String,System.Int64,System.IO.Stream)">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="contentLength">Number of bytes to send from the stream.</param>
+			<param name="stream">Stream containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeout(System.Int32,System.Guid,System.Int64,System.IO.Stream)">
+			<summary>
+				Send data to the specified client by GUID.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="guid">Client GUID.</param>
+			<param name="contentLength">Number of bytes to send from the stream.</param>
+			<param name="stream">Stream containing data to send.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendAsync(System.String,System.String,System.Threading.CancellationToken)">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="data">String containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendAsync(System.Guid,System.String,System.Threading.CancellationToken)">
+			<summary>
+				Send data to the specified client by GUID.
+			</summary>
+			<param name="guid">Client GUID.</param>
+			<param name="data">String containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendAsync(System.String,System.Byte[],System.Threading.CancellationToken)">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="data">Byte array containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendAsync(System.Guid,System.Byte[],System.Threading.CancellationToken)">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="guid">Client GUID.</param>
+			<param name="data">Byte array containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendAsync(System.String,System.Int64,System.IO.Stream,System.Threading.CancellationToken)">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="contentLength">Number of bytes to send from the stream.</param>
+			<param name="stream">Stream containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendAsync(System.Guid,System.Int64,System.IO.Stream,System.Threading.CancellationToken)">
+			<summary>
+				Send data to the specified client by GUID.
+			</summary>
+			<param name="guid">Client GUID.</param>
+			<param name="contentLength">Number of bytes to send from the stream.</param>
+			<param name="stream">Stream containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeoutAsync(System.Int32,System.String,System.String,System.Threading.CancellationToken)">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="data">String containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeoutAsync(System.Int32,System.Guid,System.String,System.Threading.CancellationToken)">
+			<summary>
+				Send data to the specified client by GUID.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="guid">Client GUID.</param>
+			<param name="data">String containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeoutAsync(System.Int32,System.String,System.Byte[],System.Threading.CancellationToken)">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="data">Byte array containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeoutAsync(System.Int32,System.Guid,System.Byte[],System.Threading.CancellationToken)">
+			<summary>
+				Send data to the specified client by GUID.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="guid">Client GUID.</param>
+			<param name="data">Byte array containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeoutAsync(System.Int32,System.String,System.Int64,System.IO.Stream,System.Threading.CancellationToken)">
+			<summary>
+				Send data to the specified client by IP:port.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="contentLength">Number of bytes to send from the stream.</param>
+			<param name="stream">Stream containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.SendWithTimeoutAsync(System.Int32,System.Guid,System.Int64,System.IO.Stream,System.Threading.CancellationToken)">
+			<summary>
+				Send data to the specified client by GUID.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="guid">Client GUID.</param>
+			<param name="contentLength">Number of bytes to send from the stream.</param>
+			<param name="stream">Stream containing data to send.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>WriteResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.DisconnectClient(System.String)">
+			<summary>
+				Disconnects the specified client.
+			</summary>
+			<param name="ipPort">IP:port of the client.</param>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.DisconnectClient(System.Guid)">
+			<summary>
+				Disconnects the specified client.
+			</summary>
+			<param name="guid">Client GUID.</param>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.Read(System.String,System.Int32)">
+			<summary>
+				Read data from a given client.
+			</summary>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="count">The number of bytes to read.</param>
+			<returns>ReadResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.Read(System.Guid,System.Int32)">
+			<summary>
+				Read data from a given client.
+			</summary>
+			<param name="guid">Client GUID.</param>
+			<param name="count">The number of bytes to read.</param>
+			<returns>ReadResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.ReadWithTimeout(System.Int32,System.String,System.Int32)">
+			<summary>
+				Read data from a given client.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="count">The number of bytes to read.</param>
+			<returns>ReadResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.ReadWithTimeout(System.Int32,System.Guid,System.Int32)">
+			<summary>
+				Read data from a given client.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="guid">Client GUID.</param>
+			<param name="count">The number of bytes to read.</param>
+			<returns>ReadResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.ReadAsync(System.String,System.Int32,System.Threading.CancellationToken)">
+			<summary>
+				Read data from a given client.
+			</summary>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="count">The number of bytes to read.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>ReadResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.ReadAsync(System.Guid,System.Int32,System.Threading.CancellationToken)">
+			<summary>
+				Read data from a given client.
+			</summary>
+			<param name="guid">Client GUID.</param>
+			<param name="count">The number of bytes to read.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>ReadResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.ReadWithTimeoutAsync(System.Int32,System.String,System.Int32,System.Threading.CancellationToken)">
+			<summary>
+				Read data from a given client.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="ipPort">The client IP:port.</param>
+			<param name="count">The number of bytes to read.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>ReadResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.ReadWithTimeoutAsync(System.Int32,System.Guid,System.Int32,System.Threading.CancellationToken)">
+			<summary>
+				Read data from a given client.
+			</summary>
+			<param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+			<param name="guid">Client GUID.</param>
+			<param name="count">The number of bytes to read.</param>
+			<param name="token">Cancellation token for canceling the request.</param>
+			<returns>ReadResult.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.GetStream(System.String)">
+			<summary>
+				Get direct access to the underlying client stream.
+			</summary>
+			<param name="ipPort">The client IP:port.</param>
+			<returns>Stream.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.GetStream(System.Guid)">
+			<summary>
+				Get direct access to the underlying client stream.
+			</summary>
+			<param name="guid">Client GUID.</param>
+			<returns>Stream.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.IsConnected(System.String)">
+			<summary>
+				Determines if a client is connected by its IP:port.
+			</summary>
+			<param name="ipPort">The client IP:port.</param>
+			<returns>True if connected.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.IsConnected(System.Guid)">
+			<summary>
+				Determines if a client is connected by its GUID.
+			</summary>
+			<param name="guid">The client GUID.</param>
+			<returns>True if connected.</returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServer.Dispose(System.Boolean)">
+			<summary>
+				Dispose of the TCP server.
+			</summary>
+			<param name="disposing">Dispose of resources.</param>
+		</member>
+		<member name="T:CavemanTcp.CavemanTcpServerCallbacks">
+			<summary>
+				CavemanTcp server callbacks.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.CavemanTcpServerCallbacks.AuthorizeConnection">
+			<summary>
+				Callback to invoke when a connection is received to permit or deny the connection.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServerCallbacks.#ctor">
+			<summary>
+				Instantiate the object.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.CavemanTcpServerEvents">
+			<summary>
+				CavemanTcp server events.
+			</summary>
+		</member>
+		<member name="E:CavemanTcp.CavemanTcpServerEvents.ClientConnected">
+			<summary>
+				Event to fire when a client connects.  A string containing the client IP:port will be passed.
+			</summary>
+		</member>
+		<member name="E:CavemanTcp.CavemanTcpServerEvents.ClientDisconnected">
+			<summary>
+				Event to fire when a client disconnects.  A string containing the client IP:port will be passed.
+			</summary>
+		</member>
+		<member name="E:CavemanTcp.CavemanTcpServerEvents.ExceptionEncountered">
+			<summary>
+				Event to fire when an exception is encountered.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServerEvents.#ctor">
+			<summary>
+				Instantiate the object.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.CavemanTcpServerSettings">
+			<summary>
+				CavemanTcp server settings.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpServerSettings.StreamBufferSize">
+			<summary>
+				Buffer size to use while interacting with streams.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.CavemanTcpServerSettings.MonitorClientConnections">
+			<summary>
+				Enable client connection monitoring, which checks connectivity every second.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.CavemanTcpServerSettings.AcceptInvalidCertificates">
+			<summary>
+				Enable or disable acceptance of invalid SSL certificates.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.CavemanTcpServerSettings.MutuallyAuthenticate">
+			<summary>
+				Enable or disable mutual authentication of SSL client and server.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpServerSettings.MaxConnections">
+			<summary>
+				Maximum number of connections the server will accept.
+				Default is 4096.  Value must be greater than zero.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpServerSettings.PermittedIPs">
+			<summary>
+				The list of permitted IP addresses from which connections can be received.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpServerSettings.BlockedIPs">
+			<summary>
+				The list of blocked IP addresses from which connections will be declined.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpServerSettings.#ctor">
+			<summary>
+				Instantiate the object.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.CavemanTcpStatistics">
+			<summary>
+				CavemanTcp statistics.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpStatistics.StartTime">
+			<summary>
+				The time at which the client or server was started.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpStatistics.UpTime">
+			<summary>
+				The amount of time which the client or server has been up.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpStatistics.ReceivedBytes">
+			<summary>
+				The number of bytes received.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.CavemanTcpStatistics.SentBytes">
+			<summary>
+				The number of bytes sent.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpStatistics.#ctor">
+			<summary>
+				Initialize the statistics object.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpStatistics.ToString">
+			<summary>
+				Return human-readable version of the object.
+			</summary>
+			<returns></returns>
+		</member>
+		<member name="M:CavemanTcp.CavemanTcpStatistics.Reset">
+			<summary>
+				Reset statistics other than StartTime and UpTime.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.ClientConnectedEventArgs">
+			<summary>
+				Arguments for client connection events.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.ClientConnectedEventArgs.Client">
+			<summary>
+				Client metadata.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.ClientDeclinedEventArgs">
+			<summary>
+				Arguments for situations where client connections are declined.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.ClientDeclinedEventArgs.IpPort">
+			<summary>
+				The IP address and port number of the disconnected client socket.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.ClientDeclinedEventArgs.Reason">
+			<summary>
+				The reason for the disconnection.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.ClientDisconnectedEventArgs">
+			<summary>
+				Arguments for client disconnection events.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.ClientDisconnectedEventArgs.Client">
+			<summary>
+				Client metadata.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.ClientDisconnectedEventArgs.Reason">
+			<summary>
+				The reason for the disconnection.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.ClientMetadata">
+			<summary>
+				Client metadata.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.ClientMetadata.Guid">
+			<summary>
+				Globally-unique identifier for the connection.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.ClientMetadata.IpPort">
+			<summary>
+				IP:port.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.ClientMetadata.Name">
+			<summary>
+				Name for the client, managed by the developer (you).
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.ClientMetadata.Metadata">
+			<summary>
+				Metadata for the client, managed by the developer (you).
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.ClientMetadata.Dispose">
+			<summary>
+				Tear down the object and dispose of resources.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.ClientMetadata.ToString">
+			<summary>
+				Human-readable representation of the object.
+			</summary>
+			<returns></returns>
+		</member>
+		<member name="T:CavemanTcp.DisconnectReason">
+			<summary>
+				Reason why a client disconnected.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.DisconnectReason.Normal">
+			<summary>
+				Normal disconnection.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.DisconnectReason.Kicked">
+			<summary>
+				Client connection was intentionally terminated programmatically or by the server.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.DisconnectReason.Timeout">
+			<summary>
+				Client connection timed out; server did not receive data within the timeout window.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.DisconnectReason.ConnectionDeclined">
+			<summary>
+				The connection was declined.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.ExceptionEventArgs">
+			<summary>
+				Event arguments for when an exception is encountered.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.ExceptionEventArgs.Exception">
+			<summary>
+				Exception.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.ReadResult">
+			<summary>
+				Result of a read operation.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.ReadResult.Status">
+			<summary>
+				Status of the read operation.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.ReadResult.BytesRead">
+			<summary>
+				Number of bytes read.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.ReadResult.DataStream">
+			<summary>
+				Stream containing data.
+			</summary>
+		</member>
+		<member name="P:CavemanTcp.ReadResult.Data">
+			<summary>
+				Byte data from the stream.  Using this property will fully read the data stream and it will no longer be readable.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.ReadResult.#ctor">
+			<summary>
+				Instantiate the object.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.ReadResult.#ctor(CavemanTcp.ReadResultStatus,System.Int64,System.IO.MemoryStream)">
+			<summary>
+				Instantiate the object.
+			</summary>
+			<param name="status">Status of the read operation.</param>
+			<param name="bytesRead">Number of bytes read.</param>
+			<param name="data">Stream containing data.</param>
+		</member>
+		<member name="T:CavemanTcp.ReadResultStatus">
+			<summary>
+				Read result status.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.ReadResultStatus.ClientNotFound">
+			<summary>
+				The requested client was not found (only applicable for server read requests).
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.ReadResultStatus.Success">
+			<summary>
+				The read operation was successful.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.ReadResultStatus.Timeout">
+			<summary>
+				The operation timed out (reserved for future use).
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.ReadResultStatus.Disconnected">
+			<summary>
+				The connection was lost.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.ReadResultStatus.Canceled">
+			<summary>
+				The request was canceled.
+			</summary>
+		</member>
+		<member name="T:CavemanTcp.WriteResult">
+			<summary>
+				Result of a write operation.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.WriteResult.Status">
+			<summary>
+				Status of the write operation.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.WriteResult.BytesWritten">
+			<summary>
+				Number of bytes written.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.WriteResult.#ctor">
+			<summary>
+				Instantiate the object.
+			</summary>
+		</member>
+		<member name="M:CavemanTcp.WriteResult.#ctor(CavemanTcp.WriteResultStatus,System.Int64)">
+			<summary>
+				Instantiate the object.
+			</summary>
+			<param name="status">Status of the write operation.</param>
+			<param name="bytesWritten">Number of bytes written.</param>
+		</member>
+		<member name="T:CavemanTcp.WriteResultStatus">
+			<summary>
+				Write result status.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.WriteResultStatus.ClientNotFound">
+			<summary>
+				The requested client was not found (only applicable for server read requests).
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.WriteResultStatus.Success">
+			<summary>
+				The write operation was successful.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.WriteResultStatus.Timeout">
+			<summary>
+				The operation timed out (reserved for future use).
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.WriteResultStatus.Disconnected">
+			<summary>
+				The connection was lost.
+			</summary>
+		</member>
+		<member name="F:CavemanTcp.WriteResultStatus.Canceled">
+			<summary>
+				The request was canceled.
+			</summary>
+		</member>
+	</members>
 </doc>

--- a/src/CavemanTcp/CavemanTcpClient.cs
+++ b/src/CavemanTcp/CavemanTcpClient.cs
@@ -556,6 +556,23 @@ namespace CavemanTcp
             return ReadWithTimeoutInternal(-1, count); 
         }
 
+        /// <summary>
+        /// Read from the server.
+        /// </summary>
+        /// <param name="count">The number of bytes to read.</param>
+        /// <param name="terminator">The pattern which ends reciving message.</param>
+        /// <returns>ReadResult.</returns>
+        public ReadResult Read(int count, byte[] terminator)
+        {
+            if (count < 1) throw new ArgumentException("Count must be greater than zero.");
+            if (terminator == null) throw new ArgumentException("Terminator must be not null.");
+            if (terminator.Length == 0) throw new ArgumentException("Terminator length must be grater than 0.");
+            if (_Client == null || !_Client.Connected) throw new IOException("Client is not connected.");
+            if (!_NetworkStream.CanRead) throw new IOException("Cannot read from network stream.");
+            if (_Ssl && !_SslStream.CanRead) throw new IOException("Cannot read from SSL stream.");
+            return ReadWithTimeoutAndTerminatorInternal(-1, count, terminator);
+        }
+
         #endregion
 
         #region ReadWithTimeout
@@ -574,6 +591,25 @@ namespace CavemanTcp
             if (!_NetworkStream.CanRead) throw new IOException("Cannot read from network stream.");
             if (_Ssl && !_SslStream.CanRead) throw new IOException("Cannot read from SSL stream.");
             return ReadWithTimeoutInternal(timeoutMs, count);
+        }
+
+        /// <summary>
+        /// Read from the server.
+        /// </summary>
+        /// <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+        /// <param name="count">The number of bytes to read.</param>
+        /// <param name="terminator">The pattern which ends reciving message.</param>
+        /// <returns>ReadResult.</returns>
+        public ReadResult ReadWithTimeout(int timeoutMs, int count, byte[] terminator)
+        {
+            if (timeoutMs < -1 || timeoutMs == 0) throw new ArgumentException("TimeoutMs must be -1 (no timeout) or a positive integer.");
+            if (count < 1) throw new ArgumentException("Count must be greater than zero.");
+            if (terminator == null) throw new ArgumentException("Terminator must be not null.");
+            if (terminator.Length == 0) throw new ArgumentException("Terminator length must be grater than 0.");
+            if (_Client == null || !_Client.Connected) throw new IOException("Client is not connected.");
+            if (!_NetworkStream.CanRead) throw new IOException("Cannot read from network stream.");
+            if (_Ssl && !_SslStream.CanRead) throw new IOException("Cannot read from SSL stream.");
+            return ReadWithTimeoutAndTerminatorInternal(timeoutMs, count, terminator);
         }
 
         #endregion
@@ -596,6 +632,25 @@ namespace CavemanTcp
             return await ReadWithoutTimeoutInternalAsync(count, token).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Read from the server.
+        /// </summary>
+        /// <param name="count">The number of bytes to read.</param>
+        /// <param name="terminator">The pattern which ends reciving message.</param>
+        /// <param name="token">Cancellation token for canceling the request.</param>
+        /// <returns>ReadResult.</returns>
+        public async Task<ReadResult> ReadAsync(int count, byte[] terminator, CancellationToken token = default)
+        {
+            if (count < 1) throw new ArgumentException("Count must be greater than zero.");
+            if (terminator == null) throw new ArgumentException("Terminator must be not null.");
+            if (terminator.Length == 0) throw new ArgumentException("Terminator length must be grater than 0.");
+            if (_Client == null || !_Client.Connected) throw new IOException("Client is not connected.");
+            if (!_NetworkStream.CanRead) throw new IOException("Cannot read from network stream.");
+            if (_Ssl && !_SslStream.CanRead) throw new IOException("Cannot read from SSL stream.");
+            if (token == default(CancellationToken)) token = _Token;
+            return await ReadWithoutTimeoutAndWithTerminatorInternalAsync(count, terminator, token).ConfigureAwait(false);
+        }
+
         #endregion
 
         #region ReadWithTimeoutAsync
@@ -616,6 +671,27 @@ namespace CavemanTcp
             if (_Ssl && !_SslStream.CanRead) throw new IOException("Cannot read from SSL stream.");
             if (token == default(CancellationToken)) token = _Token;
             return await ReadWithTimeoutInternalAsync(timeoutMs, count, token).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Read from the server.
+        /// </summary>
+        /// <param name="timeoutMs">The number of milliseconds to wait before timing out the operation.  -1 indicates no timeout, otherwise the value must be a non-zero positive integer.</param>
+        /// <param name="count">The number of bytes to read.</param>
+        /// <param name="terminator">The pattern which ends reciving message.</param>
+        /// <param name="token">Cancellation token for canceling the request.</param>
+        /// <returns>ReadResult.</returns>
+        public async Task<ReadResult> ReadWithTimeoutAsync(int timeoutMs, int count, byte[] terminator, CancellationToken token = default)
+        {
+            if (timeoutMs < -1 || timeoutMs == 0) throw new ArgumentException("TimeoutMs must be -1 (no timeout) or a positive integer.");
+            if (count < 1) throw new ArgumentException("Count must be greater than zero.");
+            if (terminator == null) throw new ArgumentException("Terminator must be not null.");
+            if (terminator.Length == 0) throw new ArgumentException("Terminator length must be grater than 0.");
+            if (_Client == null || !_Client.Connected) throw new IOException("Client is not connected.");
+            if (!_NetworkStream.CanRead) throw new IOException("Cannot read from network stream.");
+            if (_Ssl && !_SslStream.CanRead) throw new IOException("Cannot read from SSL stream.");
+            if (token == default(CancellationToken)) token = _Token;
+            return await ReadWithTimeoutAndTerminatorInternalAsync(timeoutMs, count, terminator, token).ConfigureAwait(false);
         }
 
         #endregion
@@ -1282,6 +1358,112 @@ namespace CavemanTcp
             }
         }
 
+
+        private ReadResult ReadWithTimeoutAndTerminatorInternal(int timeoutMs, long count, byte[] terminator)
+        {
+            CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_Token);
+            CancellationToken timeoutToken = timeoutCts.Token;
+
+            ReadResult result = new ReadResult(ReadResultStatus.Success, 0, null);
+
+            while (!_ReadSemaphore.Wait(10))
+            {
+                Task.Delay(10).Wait();
+            }
+
+            Task<ReadResult> task = Task.Run(() =>
+            {
+                try
+                {
+                    MemoryStream ms = new MemoryStream();
+                    // Moved here to be available/reachable if timeout or cancellation occurs
+                    result.DataStream = ms;
+                    long bytesRemaining = count;
+
+                    while (bytesRemaining > 0)
+                    {
+                        byte[] buffer = null;
+                        if (bytesRemaining >= _Settings.StreamBufferSize) buffer = new byte[_Settings.StreamBufferSize];
+                        else buffer = new byte[bytesRemaining];
+
+                        int bytesRead = 0;
+                        if (!_Ssl) bytesRead = _NetworkStream.Read(buffer, 0, buffer.Length);
+                        else bytesRead = _SslStream.Read(buffer, 0, buffer.Length);
+
+                        if (bytesRead > 0)
+                        {
+                            ms.Write(buffer, 0, bytesRead);
+                            result.BytesRead += bytesRead;
+                            _Statistics.AddReceivedBytes(bytesRead);
+                            bytesRemaining -= bytesRead;
+
+                            // if we didn't reach to target byte count check for existance of terminator pattern
+                            if (bytesRemaining > 0)
+                            {
+                                // index of terminator pattern
+                                var indexOfTerminator = ms.ToArray().Contains(terminator);
+
+                                // if stream contains pattern ignore bytes after pattern and finish reading from socket
+                                if (indexOfTerminator != -1)
+                                {
+                                    ms.SetLength(indexOfTerminator + terminator.Length);
+                                    bytesRemaining = 0;
+
+                                }
+                            }
+                        }
+                    }
+
+                    ms.Seek(0, SeekOrigin.Begin);
+                    return result;
+                }
+                catch (TaskCanceledException)
+                {
+                    result.Status = ReadResultStatus.Canceled;
+                    return result;
+                }
+                catch (OperationCanceledException)
+                {
+                    result.Status = ReadResultStatus.Canceled;
+                    return result;
+                }
+                catch (Exception)
+                {
+                    _IsConnected = false;
+                    result.Status = ReadResultStatus.Disconnected;
+                    result.DataStream = null;
+                    return result;
+                }
+            }, timeoutToken);
+
+            bool success = task.Wait(TimeSpan.FromMilliseconds(timeoutMs));
+            timeoutCts.Cancel();
+
+            _ReadSemaphore.Release();
+
+            if (success)
+            {
+                return task.Result;
+            }
+            else
+            {
+                result.Status = ReadResultStatus.Timeout;
+
+                // if MemoryStream contains data, seek to origin for making it usable by ReadResult
+                if (result.DataStream.Length > 0)
+                {
+                    result.DataStream.Seek(0, SeekOrigin.Begin);
+                }
+                else
+                {
+                    result.DataStream.Dispose();
+                    result.DataStream = null;
+                }
+
+                return result;
+            }
+        }
+
         // Supplied cancellation token
         private async Task<ReadResult> ReadWithoutTimeoutInternalAsync(long count, CancellationToken token)
         {
@@ -1343,6 +1525,95 @@ namespace CavemanTcp
             {
                 _ReadSemaphore.Release();
             } 
+        }
+
+        private async Task<ReadResult> ReadWithoutTimeoutAndWithTerminatorInternalAsync(long count, byte[] terminator, CancellationToken token)
+        {
+            ReadResult result = new ReadResult(ReadResultStatus.Success, 0, null);
+
+            try
+            {
+                while (true)
+                {
+                    bool success = await _ReadSemaphore.WaitAsync(10, token).ConfigureAwait(false);
+                    if (success) break;
+                    await Task.Delay(10).ConfigureAwait(false);
+                }
+
+                MemoryStream ms = new MemoryStream();
+                // Moved here to make stream available/reachable if cancellation occurs
+                result.DataStream = ms;
+                long bytesRemaining = count;
+
+                while (bytesRemaining > 0)
+                {
+                    byte[] buffer = null;
+                    if (bytesRemaining >= _Settings.StreamBufferSize) buffer = new byte[_Settings.StreamBufferSize];
+                    else buffer = new byte[bytesRemaining];
+
+                    int bytesRead = 0;
+                    if (!_Ssl) bytesRead = await _NetworkStream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+                    else bytesRead = await _SslStream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+
+                    if (bytesRead > 0)
+                    {
+                        await ms.WriteAsync(buffer, 0, bytesRead, token).ConfigureAwait(false);
+                        result.BytesRead += bytesRead;
+                        _Statistics.AddReceivedBytes(bytesRead);
+                        bytesRemaining -= bytesRead;
+
+                        // if we didn't reach to target byte count check for existance of terminator pattern
+                        if (bytesRemaining > 0)
+                        {
+                            // index of terminator pattern
+                            var indexOfTerminator = ms.ToArray().Contains(terminator);
+
+                            // if stream contains pattern ignore bytes after pattern and finish reading from socket
+                            if (indexOfTerminator != -1)
+                            {
+                                ms.SetLength(indexOfTerminator + terminator.Length);
+                                bytesRemaining = 0;
+                            }
+                        }
+                    }
+                }
+
+                // not needed anymore
+                //ms.Seek(0, SeekOrigin.Begin);
+                return result;
+            }
+            catch (TaskCanceledException)
+            {
+                result.Status = ReadResultStatus.Canceled;
+                return result;
+            }
+            catch (OperationCanceledException)
+            {
+                result.Status = ReadResultStatus.Canceled;
+                return result;
+            }
+            catch (Exception)
+            {
+                _IsConnected = false;
+                result.Status = ReadResultStatus.Disconnected;
+                result.DataStream = null;
+                return result;
+            }
+            finally
+            {
+                // if MemoryStream contains data, seek to origin for making it usable by ReadResult
+                if (result.DataStream.Length > 0)
+                {
+                    result.DataStream.Seek(0, SeekOrigin.Begin);
+                }
+                else
+                {
+                    result.DataStream.Dispose();
+                    result.DataStream = null;
+                }
+
+                _ReadSemaphore.Release();
+            }
         }
 
         // Supplied cancellation token, timeout cancellation token
@@ -1423,6 +1694,115 @@ namespace CavemanTcp
             else
             {
                 result.Status = ReadResultStatus.Timeout;
+                return result;
+            }
+        }
+
+        private async Task<ReadResult> ReadWithTimeoutAndTerminatorInternalAsync(int timeoutMs, long count, byte[] terminator, CancellationToken token)
+        {
+            CancellationTokenSource timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(_Token, token);
+            CancellationToken timeoutToken = timeoutCts.Token;
+
+            ReadResult result = new ReadResult(ReadResultStatus.Success, 0, null);
+
+            while (true)
+            {
+                bool success = await _ReadSemaphore.WaitAsync(10, token).ConfigureAwait(false);
+                if (success) break;
+                await Task.Delay(10, token).ConfigureAwait(false);
+            }
+
+            Task<ReadResult> task = Task.Run(async () =>
+            {
+                try
+                {
+                    MemoryStream ms = new MemoryStream();
+
+                    // Moved here to be available/reachable if timeout or cancellation occurs
+                    result.DataStream = ms;
+                    long bytesRemaining = count;
+
+                    while (bytesRemaining > 0)
+                    {
+                        byte[] buffer = null;
+                        if (bytesRemaining >= _Settings.StreamBufferSize) buffer = new byte[_Settings.StreamBufferSize];
+                        else buffer = new byte[bytesRemaining];
+
+                        int bytesRead = 0;
+                        if (!_Ssl) bytesRead = await _NetworkStream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+                        else bytesRead = await _SslStream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+
+                        if (bytesRead > 0)
+                        {
+                            result.BytesRead += bytesRead;
+                            await ms.WriteAsync(buffer, 0, bytesRead, token).ConfigureAwait(false);
+                            _Statistics.AddReceivedBytes(bytesRead);
+                            bytesRemaining -= bytesRead;
+
+                            // if we didn't reach to target byte count check for existance of terminator pattern
+                            if (bytesRemaining > 0)
+                            {
+                                // index of terminator pattern
+                                var indexOfTerminator = ms.ToArray().Contains(terminator);
+
+                                // if stream contains pattern ignore bytes after pattern and finish reading from socket
+                                if (indexOfTerminator != -1)
+                                {
+                                    ms.SetLength(indexOfTerminator + terminator.Length);
+                                    bytesRemaining = 0;
+                                }
+                            }
+                        }
+                    }
+
+                    ms.Seek(0, SeekOrigin.Begin);
+                    return result;
+                }
+                catch (TaskCanceledException)
+                {
+                    result.Status = ReadResultStatus.Canceled;
+                    return result;
+                }
+                catch (OperationCanceledException)
+                {
+                    result.Status = ReadResultStatus.Canceled;
+                    return result;
+                }
+                catch (Exception)
+                {
+                    _IsConnected = false;
+                    result.Status = ReadResultStatus.Disconnected;
+                    result.DataStream = null;
+                    return result;
+                }
+            },
+            timeoutToken);
+
+            Task delay = Task.Delay(timeoutMs, token);
+            Task first = await Task.WhenAny(task, delay).ConfigureAwait(false);
+            timeoutCts.Cancel();
+
+            _ReadSemaphore.Release();
+
+            if (first == task)
+            {
+                return task.Result;
+            }
+            else
+            {
+                result.Status = ReadResultStatus.Timeout;
+
+                // if MemoryStream contains data, seek to origin for making it usable by ReadResult
+                if (result.DataStream.Length > 0)
+                {
+                    result.DataStream.Seek(0, SeekOrigin.Begin);
+                }
+                else
+                {
+                    result.DataStream.Dispose();
+                    result.DataStream = null;
+                }
+
                 return result;
             }
         }

--- a/src/CavemanTcp/Common.cs
+++ b/src/CavemanTcp/Common.cs
@@ -65,5 +65,64 @@ namespace CavemanTcp
                 port = Convert.ToInt32(ipPort.Substring(colonIndex + 1));
             }
         }
+
+        /// <summary>
+        /// Determines whether a byte array contains the specified sequence of bytes.
+        /// </summary>
+        /// <param name="caller">The byte array to be searched.</param>
+        /// <param name="array">The byte to be found.</param>
+        /// <returns>The first location of the sequence within the array, -1 if the sequence is not found.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        internal static int Contains(this byte[] caller, byte[] array)
+        {
+            byte startValue, endValue;
+            int result, arrayLength, searchBoundary, j, startLocation, endOffset;
+
+            if (caller == null)
+                throw new ArgumentNullException($"{nameof(caller)}");
+            if (array == null)
+                throw new ArgumentNullException($"{nameof(array)}");
+            if (caller.Length == 0 || array.Length == 0)
+                throw new ArgumentException($"Argument {(caller.Length == 0 ? nameof(caller) : nameof(array))} is empty.");
+
+            if (array.Length > caller.Length)
+                return -1;
+
+            startValue = array[0];
+            arrayLength = array.Length;
+
+            if (arrayLength > 1)
+            {
+                result = -1;
+                endOffset = arrayLength - 1;
+                endValue = array[endOffset];
+                searchBoundary = caller.Length - arrayLength;
+                startLocation = -1;
+
+                while ((startLocation = Array.IndexOf(caller, startValue, startLocation + 1)) >= 0)
+                {
+                    if (startLocation > searchBoundary)
+                        break;
+
+                    if (caller[startLocation + endOffset] == endValue)
+                    {
+                        for (j = 1; j < endOffset && caller[startLocation + j] == array[j]; j++) { }
+
+                        if (j == endOffset)
+                        {
+                            result = startLocation;
+                            break;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                result = Array.IndexOf(caller, startValue);
+            }
+
+            return result;
+        }
     }
 }


### PR DESCRIPTION
Hi,

Actually this pull request is somehow linked to my previous pull request. In short if we send a request to a device and expect for example 25 bytes long response but instead we receive 13 bytes response to complete read TcpClient will wait until timeout. But some devices (like the one i am working with now) have fixed message termination sequences (like { 0x03, 0x02 } or line feed etc. ) So to eleminate extra wait I added an option to read methods to search received data for message termination sequence and if found finalize reading and resize stream according to sequence position.