### PR TITLE
Add support to CavemanTcpClient for server side validation only (non mutual TLS)

### DIFF
--- a/src/CavemanTcp/CavemanTcp.xml
+++ b/src/CavemanTcp/CavemanTcp.xml
@@ -46,6 +46,14 @@
             </summary>
             <param name="ipPort">The IP:port of the server.</param> 
         </member>
+        <member name="M:CavemanTcp.CavemanTcpClient.#ctor(System.String,System.Int32,System.Boolean)">
+            <summary>
+            Instantiates the TCP client.  Set the Connected, Disconnected, and DataReceived callbacks.  Once set, use Connect() to connect to the server.
+            </summary>
+            <param name="serverIpOrHostname">The server IP address or hostname.</param>
+            <param name="port">The TCP port on which to connect.</param>
+            <param name="ssl">Enable or disable SSL.</param>
+        </member>
         <member name="M:CavemanTcp.CavemanTcpClient.#ctor(System.String,System.Int32,System.Security.Cryptography.X509Certificates.X509Certificate2)">
             <summary>
             Instantiates the TCP client without SSL.  Set the Connected, Disconnected, and DataReceived callbacks.  Once set, use Connect() to connect to the server.
@@ -72,14 +80,6 @@
             <param name="ssl">Enable or disable SSL.</param>
             <param name="pfxCertFilename">The filename of the PFX certificate file.</param>
             <param name="pfxPassword">The password to the PFX certificate file.</param>
-        </member>
-        <member name="M:CavemanTcp.CavemanTcpClient.#ctor(System.String,System.Int32,System.Boolean)">
-            <summary>
-            Instantiates the TCP client with ssl, authenticating server only.
-            </summary>
-            <param name="serverIpOrHostname">The server IP address or hostname.</param>
-            <param name="port">The TCP port on which to connect.</param>
-            <param name="ssl">Enable or disable SSL.</param>
         </member>
         <member name="M:CavemanTcp.CavemanTcpClient.Dispose">
             <summary>
@@ -278,6 +278,19 @@
         <member name="P:CavemanTcp.CavemanTcpClientSettings.AcceptInvalidCertificates">
             <summary>
             Enable or disable acceptance of invalid SSL certificates.
+            </summary>
+        </member>
+        <member name="P:CavemanTcp.CavemanTcpClientSettings.CheckCertificateRevocation">
+            <summary>
+            Enable or disable this to perform certificate revocation checks.  This is in addition to the accept
+             invalid certificates setting which just decides to ignore issues that arise in the call back during the
+             authentication phase.
+            
+            The client performs the revocation check by using either the Certificate Revocation List (CRL) or the
+            Online Certificate Status Protocol (OCSP).
+            
+            By default this value is set to false.  If AcceptInvalidCertificates is set to true, then this value will be
+            set to false at runtime. 
             </summary>
         </member>
         <member name="P:CavemanTcp.CavemanTcpClientSettings.MutuallyAuthenticate">

--- a/src/CavemanTcp/CavemanTcp.xml
+++ b/src/CavemanTcp/CavemanTcp.xml
@@ -73,6 +73,14 @@
             <param name="pfxCertFilename">The filename of the PFX certificate file.</param>
             <param name="pfxPassword">The password to the PFX certificate file.</param>
         </member>
+        <member name="M:CavemanTcp.CavemanTcpClient.#ctor(System.String,System.Int32,System.Boolean)">
+            <summary>
+            Instantiates the TCP client with ssl, authenticating server only.
+            </summary>
+            <param name="serverIpOrHostname">The server IP address or hostname.</param>
+            <param name="port">The TCP port on which to connect.</param>
+            <param name="ssl">Enable or disable SSL.</param>
+        </member>
         <member name="M:CavemanTcp.CavemanTcpClient.Dispose">
             <summary>
             Dispose of the TCP client.

--- a/src/CavemanTcp/CavemanTcp.xml
+++ b/src/CavemanTcp/CavemanTcp.xml
@@ -282,15 +282,16 @@
         </member>
         <member name="P:CavemanTcp.CavemanTcpClientSettings.CheckCertificateRevocation">
             <summary>
-            Enable or disable this to perform certificate revocation checks.  This is in addition to the accept
-             invalid certificates setting which just decides to ignore issues that arise in the call back during the
+            Enable or disable this to tell the TcpClient perform certificate revocation checks.  This is not to be confused
+             with AcceptInvalidCertificates setting which decides whether to ignore issues that arise in the call back during the
              authentication phase.
             
-            The client performs the revocation check by using either the Certificate Revocation List (CRL) or the
-            Online Certificate Status Protocol (OCSP).
+            With this setting on, in addition to the certificate validation the client performs a revocation check by using either
+             the Certificate Revocation List (CRL) or the Online Certificate Status Protocol (OCSP).
+             This may not always be needed, which is why this option is exposed here.
             
             By default this value is set to false.  If AcceptInvalidCertificates is set to true, then this value will be
-            set to false at runtime. 
+             set to false at runtime. 
             </summary>
         </member>
         <member name="P:CavemanTcp.CavemanTcpClientSettings.MutuallyAuthenticate">

--- a/src/CavemanTcp/CavemanTcpClient.cs
+++ b/src/CavemanTcp/CavemanTcpClient.cs
@@ -320,7 +320,7 @@ namespace CavemanTcp
                     else
                     {
                         // do not accept invalid SSL certificates
-                        _SslStream = new SslStream(_NetworkStream, false);
+                        _SslStream = new SslStream(_NetworkStream, false, ValidateServerCertificate);
                     }
 
                     _SslStream.AuthenticateAsClient(_ServerIp, _SslCertificateCollection, Common.GetSslProtocol, !_Settings.AcceptInvalidCertificates);
@@ -366,6 +366,7 @@ namespace CavemanTcp
                 wh.Close();
             }
         }
+
 
         /// <summary>
         /// Disconnect from the server.
@@ -912,6 +913,18 @@ namespace CavemanTcp
         private bool AcceptCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         { 
             return _Settings.AcceptInvalidCertificates;
+        }
+        
+        private bool ValidateServerCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        {
+            if (sslPolicyErrors == SslPolicyErrors.None)
+            {
+                return true;
+            }
+            
+            Logger?.Invoke(_Header + $"Certificate error: {sslPolicyErrors}");
+
+            return false;
         }
 
         private async Task ConnectionMonitor()

--- a/src/CavemanTcp/CavemanTcpClient.cs
+++ b/src/CavemanTcp/CavemanTcpClient.cs
@@ -924,6 +924,46 @@ namespace CavemanTcp
             
             Logger?.Invoke(_Header + $"Certificate error: {sslPolicyErrors}");
 
+            if (chain != null && chain.ChainElements.Count > 0)
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.AppendLine($"Chain element information ({chain.ChainElements.Count} found) ...");
+                sb.AppendLine();
+                
+                for (int i = 0; i < chain.ChainElements.Count; i++)
+                {
+                    X509ChainElement element = chain.ChainElements[i];
+                    sb.AppendLine($"Number: {i}");
+                    sb.AppendLine($"Subject: {element.Certificate.Subject}");
+                    sb.AppendLine($"Issuer: {element.Certificate.Issuer}");
+                    sb.AppendLine($"Thumbprint: {element.Certificate.Thumbprint}");
+                    sb.AppendLine(
+                        $"Validity Period: {element.Certificate.NotBefore} to {element.Certificate.NotAfter}");
+
+                    if (element.ChainElementStatus.Any())
+                    {
+                        sb.AppendLine();
+                        sb.AppendLine($"Element chain status information ({element.ChainElementStatus.Length} found): ");
+                        sb.AppendLine();
+                        foreach (X509ChainStatus status in element.ChainElementStatus)
+                        {
+                            if (status.Status != X509ChainStatusFlags.NoError)
+                            {
+                                sb.AppendLine($"Status: {status.Status}");
+                                sb.AppendLine($"Status Information: {status.StatusInformation}");
+                            }
+                        }
+                        
+                    }
+
+                    sb.AppendLine("---");
+                }
+
+                sb.AppendLine("End of chain element information");
+                
+                Logger?.Invoke(_Header + $"{sb}");
+            }
+
             return false;
         }
 

--- a/src/CavemanTcp/CavemanTcpClient.cs
+++ b/src/CavemanTcp/CavemanTcpClient.cs
@@ -316,6 +316,9 @@ namespace CavemanTcp
                     {
                         // accept invalid certs
                         _SslStream = new SslStream(_NetworkStream, false, new RemoteCertificateValidationCallback(AcceptCertificate));
+
+                        // override the online revoca
+                        _Settings.CheckCertificateRevocation = false;
                     }
                     else
                     {
@@ -323,7 +326,7 @@ namespace CavemanTcp
                         _SslStream = new SslStream(_NetworkStream, false, ValidateServerCertificate);
                     }
 
-                    _SslStream.AuthenticateAsClient(_ServerIp, _SslCertificateCollection, Common.GetSslProtocol, !_Settings.AcceptInvalidCertificates);
+                    _SslStream.AuthenticateAsClient(_ServerIp, _SslCertificateCollection, Common.GetSslProtocol, _Settings.CheckCertificateRevocation);
 
                     if (!_SslStream.IsEncrypted)
                     {
@@ -924,6 +927,7 @@ namespace CavemanTcp
             
             Logger?.Invoke(_Header + $"Certificate error: {sslPolicyErrors}");
 
+            // if we have a certificate chain, log this for debugging.
             if (chain != null && chain.ChainElements.Count > 0)
             {
                 StringBuilder sb = new StringBuilder();

--- a/src/CavemanTcp/CavemanTcpClientSettings.cs
+++ b/src/CavemanTcp/CavemanTcpClientSettings.cs
@@ -33,6 +33,20 @@ namespace CavemanTcp
         public bool AcceptInvalidCertificates { get; set; } = true;
 
         /// <summary>
+        /// Enable or disable this to tell the TcpClient perform certificate revocation checks.  This is not to be confused
+        ///  with AcceptInvalidCertificates setting which decides whether to ignore issues that arise in the call back during the
+        ///  authentication phase.
+        /// 
+        /// With this setting on, in addition to the certificate validation the client performs a revocation check by using either
+        ///  the Certificate Revocation List (CRL) or the Online Certificate Status Protocol (OCSP).
+        ///  This may not always be needed, which is why this option is exposed here.
+        /// 
+        /// By default this value is set to false.  If AcceptInvalidCertificates is set to true, then this value will be
+        ///  set to false at runtime. 
+        /// </summary>
+        public bool CheckCertificateRevocation { get; set; } = false;
+
+        /// <summary>
         /// Enable or disable mutual authentication of SSL client and server.
         /// </summary>
         public bool MutuallyAuthenticate { get; set; } = false;


### PR DESCRIPTION
Hi,

I have been using this library in a number of projects recently and has worked really well, however I needed to make some modifications to handle a TLS use case in a project I was working on.  I am submitting these changes for review to see if they fit in the main branch,

- All existing constructors needed to load a certificate in some form in order to activate ssl, in my use case I just wanted to perform TLS with server certificate validation only.  A new constructor was added to support this.

- Also a new validation call back was added to support diagnostics when there are certificate issues encountered, this includes logging out the certificate chain if there is a problem to help debug. 

- Within the client settings, in addition to an existing AcceptInvalidCertificates setting, I propose an additional CheckCertificateRevocation setting which gets used by the SslStream AuthenticateAsClient method in order to determine if the validation should include a online revocation check.  In my use case, I only wanted to validate the certificate but not go online to try check the revocation list (CRL).  I believe in the other overloads of the framework AuthenicateAsClient method that this defaults to false anyway if not set.