### PR TITLE
fix exception event after dispose

### DIFF
--- a/src/CavemanTcp/CavemanTcpClient.cs
+++ b/src/CavemanTcp/CavemanTcpClient.cs
@@ -722,6 +722,7 @@
                 }
                 finally
                 {
+                    _Events.ClearAllEventHandlers();
                     _ReadSemaphore.Release();
                     _WriteSemaphore.Release();
                 }

--- a/src/CavemanTcp/CavemanTcpClientEvents.cs
+++ b/src/CavemanTcp/CavemanTcpClientEvents.cs
@@ -14,17 +14,29 @@
         /// <summary>
         /// Event to fire when the client connects.
         /// </summary>
-        public event EventHandler ClientConnected;
-
+        public event EventHandler ClientConnected
+        {
+            add => _ClientConnected += value;
+            remove => _ClientConnected -= value;
+        }
+        
         /// <summary>
         /// Event to fire when the client disconnects.
         /// </summary>
-        public event EventHandler ClientDisconnected;
-         
+        public event EventHandler ClientDisconnected
+        {
+            add => _ClientDisconnected += value;
+            remove => _ClientDisconnected -= value;
+        }
+
         /// <summary>
         /// Event to fire when an exception is encountered.
         /// </summary>
-        public event EventHandler<ExceptionEventArgs> ExceptionEncountered; 
+        public event EventHandler<ExceptionEventArgs> ExceptionEncountered
+        {
+            add => _ExceptionEncountered += value;
+            remove => _ExceptionEncountered -= value;
+        }
 
         #endregion
 
@@ -32,6 +44,10 @@
 
         private bool _ClientConnectedFiring = false;
         private bool _ClientDisconnectedFiring = false;
+
+        private EventHandler _ClientConnected;
+        private EventHandler _ClientDisconnected;
+        private EventHandler<ExceptionEventArgs> _ExceptionEncountered;
 
         #endregion
 
@@ -53,12 +69,19 @@
 
         #region Internal-Methods
 
+        internal void ClearAllEventHandlers()
+        {
+            _ClientConnected = null;
+            _ClientDisconnected = null;
+            _ExceptionEncountered = null;
+        }
+
         internal void HandleClientConnected(object sender)
         {
             if (_ClientConnectedFiring) return;
 
             _ClientConnectedFiring = true;
-            WrappedEventHandler(() => ClientConnected?.Invoke(sender, EventArgs.Empty), "ClientConnected", sender);
+            WrappedEventHandler(() => _ClientConnected?.Invoke(sender, EventArgs.Empty), "ClientConnected", sender);
             _ClientConnectedFiring = false;
         }
 
@@ -67,14 +90,14 @@
             if (_ClientDisconnectedFiring) return;
 
             _ClientDisconnectedFiring = true; 
-            WrappedEventHandler(() => ClientDisconnected?.Invoke(sender, EventArgs.Empty), "ClientDisconnected", sender);
+            WrappedEventHandler(() => _ClientDisconnected?.Invoke(sender, EventArgs.Empty), "ClientDisconnected", sender);
             _ClientDisconnectedFiring = false;
         }
 
         internal void HandleExceptionEncountered(object sender, Exception e)
         {
             ExceptionEventArgs args = new ExceptionEventArgs(e);
-            WrappedEventHandler(() => ExceptionEncountered?.Invoke(sender, args), "ExceptionEncountered", sender);
+            WrappedEventHandler(() => _ExceptionEncountered?.Invoke(sender, args), "ExceptionEncountered", sender);
         }
 
         #endregion

--- a/src/CavemanTcp/CavemanTcpServer.cs
+++ b/src/CavemanTcp/CavemanTcpServer.cs
@@ -1134,6 +1134,10 @@
                         Environment.NewLine);
                     _Events.HandleExceptionEncountered(this, e);
                 }
+                finally
+                {
+                    _Events.ClearAllEventHandlers();
+                }
 
                 _IsListening = false;
 

--- a/src/CavemanTcp/CavemanTcpServerEvents.cs
+++ b/src/CavemanTcp/CavemanTcpServerEvents.cs
@@ -14,21 +14,38 @@
         /// <summary>
         /// Event to fire when a client connects.  A string containing the client IP:port will be passed.
         /// </summary>
-        public event EventHandler<ClientConnectedEventArgs> ClientConnected;
+        public event EventHandler<ClientConnectedEventArgs> ClientConnected
+        {
+            add => _ClientConnected += value;
+            remove => _ClientConnected -= value;
+        }
 
         /// <summary>
         /// Event to fire when a client disconnects.  A string containing the client IP:port will be passed.
         /// </summary>
-        public event EventHandler<ClientDisconnectedEventArgs> ClientDisconnected;
-
+        public event EventHandler<ClientDisconnectedEventArgs> ClientDisconnected
+        {
+            add => _ClientDisconnected += value;
+            remove => _ClientDisconnected -= value;
+        }
+        
         /// <summary>
         /// Event to fire when an exception is encountered.
         /// </summary>
-        public event EventHandler<ExceptionEventArgs> ExceptionEncountered;
+        public event EventHandler<ExceptionEventArgs> ExceptionEncountered
+        {
+            add => _ExceptionEncountered += value;
+            remove => _ExceptionEncountered -= value;
+        }
+
 
         #endregion
 
         #region Private-Members
+
+        private EventHandler<ClientConnectedEventArgs> _ClientConnected;
+        private EventHandler<ClientDisconnectedEventArgs> _ClientDisconnected;
+        private EventHandler<ExceptionEventArgs> _ExceptionEncountered;
 
         #endregion
 
@@ -49,21 +66,27 @@
         #endregion
 
         #region Internal-Methods
-         
+        internal void ClearAllEventHandlers()
+        {
+            _ClientConnected = null;
+            _ClientDisconnected = null;
+            _ExceptionEncountered = null;
+        }
+
         internal void HandleClientConnected(object sender, ClientConnectedEventArgs args)
         { 
-            WrappedEventHandler(() => ClientConnected?.Invoke(sender, args), "ClientConnected", sender);
+            WrappedEventHandler(() => _ClientConnected?.Invoke(sender, args), "ClientConnected", sender);
         }
 
         internal void HandleClientDisconnected(object sender, ClientDisconnectedEventArgs args)
         { 
-            WrappedEventHandler(() => ClientDisconnected?.Invoke(sender, args), "ClientDisconnected", sender);
+            WrappedEventHandler(() => _ClientDisconnected?.Invoke(sender, args), "ClientDisconnected", sender);
         }
 
         internal void HandleExceptionEncountered(object sender, Exception e)
         {
             ExceptionEventArgs args = new ExceptionEventArgs(e);
-            WrappedEventHandler(() => ExceptionEncountered?.Invoke(sender, args), "ExceptionEncountered", sender);
+            WrappedEventHandler(() => _ExceptionEncountered?.Invoke(sender, args), "ExceptionEncountered", sender);
         }
 
         #endregion


### PR DESCRIPTION
this issue occurs on net8.0 or net9.0, net framework does not have this

replace Main function in Test.Server project to reproduce


        static async Task Main(string[] args)
        {
            _Server = new CavemanTcpServer(_Hostname, _Port, _Ssl, null, null);
            _Server.Events.ClientConnected += (s, e) =>
            {
                Console.WriteLine("server events on client connected: " + e.Client.ToString());
            };
            _Server.Events.ClientDisconnected += (s, e) =>
            {
                Console.WriteLine("server events on client disconnected: " + e.Client.ToString());
            };
            _Server.Events.ExceptionEncountered += (s, e) =>
            {
                Console.WriteLine("server events on exception: " + e.Exception.ToString());
            };
            _Server.Start();

            Console.WriteLine("wait server start");
            await Task.Delay(100);

            Console.WriteLine("before stop");
            _Server.Stop();// do we need call stop before dispose? dispose does not call stop internally
            Console.WriteLine("after stop");

            Console.WriteLine("before dispose");
            _Server.Dispose();
            Console.WriteLine("after dispose");

            await Task.Delay(100);
            Console.WriteLine("after test");
        }





console output：


wait server start
before stop
after stop
before dispose
after dispose
server events on exception: System.Net.Sockets.SocketException (995): 
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.System.Threading.Tasks.Sources.IValueTaskSource<System.Net.Sockets.Socket>.GetResult(Int16 token)
   at System.Net.Sockets.TcpListener.<AcceptTcpClientAsync>g__WaitAndWrap|32_0(ValueTask`1 task)
   at CavemanTcp.CavemanTcpServer.AcceptConnections() in C:\workspace\CavemanTcp\src\CavemanTcp\CavemanTcpServer.cs:line 1315
after test

